### PR TITLE
Use Qt5 macros to detect OS

### DIFF
--- a/src/qmpwidget.cpp
+++ b/src/qmpwidget.cpp
@@ -195,17 +195,17 @@ class QMPProcess : public QProcess
 		{
 			resetValues();
 
-#ifdef Q_WS_WIN
+#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
 			m_mode = QMPwidget::EmbeddedMode;
 			m_videoOutput = "directx,directx:noaccel";
-#elif defined(Q_WS_X11)
+#elif defined(Q_WS_X11) || defined(Q_OS_UNIX) || defined(Q_OS_LINUX)
 			m_mode = QMPwidget::EmbeddedMode;
  #ifdef QT_OPENGL_LIB
 			m_videoOutput = "gl2,gl,xv";
  #else
 			m_videoOutput = "xv";
  #endif
-#elif defined(Q_WS_MAC)
+#elif defined(Q_WS_MAC) || defined(Q_OS_MACOS)
 			m_mode = QMPwidget::PipeMode;
  #ifdef QT_OPENGL_LIB
 			m_videoOutput = "gl,quartz";
@@ -273,7 +273,7 @@ class QMPProcess : public QProcess
 				myargs += "-input";
 				myargs += "nodefault-bindings:conf=/dev/null";
 			} else {
-#ifndef Q_WS_WIN
+#if !(defined(Q_WS_WIN) || defined(Q_OS_WIN))
 				// Ugly hack for older versions of mplayer (used in kmplayer and other)
 				if (m_fakeInputconf == NULL) {
 					m_fakeInputconf = new QTemporaryFile();
@@ -1009,7 +1009,7 @@ void QMPwidget::toggleFullScreen()
 		m_geometry = geometry();
 		setWindowFlags((windowFlags() | Qt::Window));
 		// From Phonon::VideoWidget
-#ifdef Q_WS_X11
+#if defined(Q_WS_X11) || defined(Q_OS_UNIX) || defined(Q_OS_LINUX)
 		show();
 		raise();
 		setWindowState(windowState() | Qt::WindowFullScreen);

--- a/src/qmpyuvreader.h
+++ b/src/qmpyuvreader.h
@@ -22,7 +22,7 @@
 #include <QMutex>
 #include <QThread>
 
-#ifdef Q_WS_WIN
+#if defined(Q_WS_WIN) || defined(Q_OS_WIN)
  #include "windows.h"
 #endif
 


### PR DESCRIPTION
I found your widget very useful and have been trying to use it on my Ubuntu 18.04, Qt5 (5.9.5). I couldn't get the mplayer window to be embedded within the widget (it kept being opened in a new window), and figured out after some debugging that the `Q_WS_*` macros have been obsolete. This PR allows using this widget on Qt5.

Note that this commit has only been tested on Ubuntu (i.e. for `Q_OS_LINUX`).

References:
- http://www.gccxml.org/Bug/view.php?id=14945
- https://doc.qt.io/archives/qt-4.8/qtglobal.html
- https://doc.qt.io/qt-5/qtglobal.html